### PR TITLE
Enable multi-agent session flow and lesson-aware UI

### DIFF
--- a/backend/src/api/services/chat.service.ts
+++ b/backend/src/api/services/chat.service.ts
@@ -7,23 +7,48 @@ import { TutorAgent } from '../../agents/tutor.agent';
 import { VerifierAgent } from '../../agents/verifier.agent';
 import { PlannerAgent } from '../../agents/planner.agent';
 import { SocraticAgent } from '../../agents/socratic.agent';
-import { Session, StudentEvent, expectsAnswer, Lesson } from '../../core/models/index';
+import { Lesson, Session, Step, StudentEvent, Turn } from '../../core/models/index';
 
 export class ChatService {
   private lessonRepo = new LessonRepo();
   private sessionRepo = new SessionRepo();
 
-  async createSession(lessonId: string, userId: string): Promise<{ sessionId: string }> {
+  async createSession(lessonId: string, userId: string): Promise<{
+    sessionId: string;
+    lesson: { id: string; title: string; totalSteps: number };
+    currentStepIndex: number;
+    initialTurns: Turn[];
+  }> {
+    const lesson = await this.lessonRepo.getById(lessonId);
     const session = this.sessionRepo.create(lessonId, userId);
-    return { sessionId: session.id };
+
+    const initialTurns = await this.prepareCurrentStep(lesson, session, {
+      forcePrompt: true
+    });
+
+    this.sessionRepo.save(session);
+
+    return {
+      sessionId: session.id,
+      lesson: {
+        id: lesson.id,
+        title: lesson.title,
+        totalSteps: lesson.steps.length
+      },
+      initialTurns,
+      currentStepIndex: session.currentStepIndex
+    };
   }
 
   async handleEvent(sessionId: string, event: StudentEvent): Promise<{
     reply: string;
+    replyRole: Turn['role'];
     stepId: string;
     isFinished: boolean;
     score?: number;
     feedback?: string;
+    nextTurns?: Turn[];
+    currentStepIndex: number;
   }> {
     const session = this.sessionRepo.get(sessionId);
     if (!session) {
@@ -31,73 +56,113 @@ export class ChatService {
     }
 
     const lesson = await this.lessonRepo.getById(session.lessonId);
-    
+    const currentStep = this.getCurrentStep(lesson, session);
+
+    if (!currentStep) {
+      session.isFinished = true;
+      this.sessionRepo.save(session);
+      return {
+        reply: 'Sesión finalizada.',
+        replyRole: 'system',
+        stepId: '',
+        isFinished: true,
+        currentStepIndex: session.currentStepIndex
+      };
+    }
+
     if (session.isFinished) {
       return {
-        reply: "Sesión finalizada.",
-        stepId: "",
-        isFinished: true
+        reply: 'Sesión finalizada.',
+        replyRole: 'system',
+        stepId: '',
+        isFinished: true,
+        currentStepIndex: session.currentStepIndex
       };
     }
 
     // 1) Interrupciones (preguntas libres)
-    if (event.type === "question") {
+    if (event.type === 'question') {
+      logTurn(session, currentStep.id, 'student', event.text);
       const help = await HelpDeskAgent.answer(lesson, session, event.text);
-      logTurn(session, this.getCurrentStep(lesson, session).id, "help", help.reply);
+      logTurn(session, currentStep.id, 'help', help.reply);
       this.sessionRepo.save(session);
-      
+
       return {
         reply: help.reply,
-        stepId: this.getCurrentStep(lesson, session).id,
-        isFinished: session.isFinished
+        replyRole: 'help',
+        stepId: currentStep.id,
+        isFinished: session.isFinished,
+        currentStepIndex: session.currentStepIndex
       };
     }
 
     // 2) Paso actual → Tutor
-    const step = this.getCurrentStep(lesson, session);
-    const tutor = await TutorAgent.handle(lesson, session, step, event);
-    logTurn(session, step.id, "tutor", tutor.reply);
+    logTurn(session, currentStep.id, 'student', event.text);
+    const tutor = await TutorAgent.handle(lesson, session, currentStep, event);
+    const tutorTurn = logTurn(session, currentStep.id, 'tutor', tutor.reply);
 
     let score: number | undefined;
     let feedback: string | undefined;
+    let findings: string[] | undefined;
 
     // 3) Verificación si aplica
-    if (expectsAnswer(step, event)) {
-      const verification = await VerifierAgent.check(lesson, session, step, event.text);
-      logTurn(session, step.id, "verifier", verification.feedback, verification.score, verification.findings);
-      
+    if (this.stepRequiresAnswer(currentStep)) {
+      const verification = await VerifierAgent.check(lesson, session, currentStep, event.text);
+      logTurn(
+        session,
+        currentStep.id,
+        'verifier',
+        verification.feedback,
+        verification.score,
+        verification.findings
+      );
+
       score = verification.score;
       feedback = verification.feedback;
+      findings = verification.findings;
+
+      const threshold = currentStep.rubric?.threshold ?? 0.6;
+      if (score !== undefined && score < threshold) {
+        const coach = await SocraticAgent.remediate(lesson, session, currentStep, findings || []);
+        logTurn(session, currentStep.id, 'socratic', coach.reply);
+
+        this.sessionRepo.save(session);
+        return {
+          reply: coach.reply,
+          replyRole: 'socratic',
+          stepId: currentStep.id,
+          isFinished: session.isFinished,
+          score,
+          feedback,
+          currentStepIndex: session.currentStepIndex
+        };
+      }
     }
 
     // 4) Decisión de avance/remediación
     const decision = await PlannerAgent.decide(lesson, session);
-    
-    // Si el score es bajo, usar Socratic Coach antes de aplicar decisión
-    if (score !== undefined && score < (step.rubric?.threshold || 0.6)) {
-      const coach = await SocraticAgent.remediate(lesson, session, step, []);
-      logTurn(session, step.id, "socratic", coach.reply);
-      
-      this.sessionRepo.save(session);
-      return {
-        reply: coach.reply,
-        stepId: step.id,
-        isFinished: session.isFinished,
-        score,
-        feedback
-      };
-    }
+    const nextStep = lesson.steps[decision.nextIndex];
+    const plannerSummary = nextStep
+      ? `${decision.rationale} → siguiente paso ${nextStep.id}`
+      : `${decision.rationale} → finalizar lección`;
+    logTurn(session, currentStep.id, 'planner', plannerSummary);
 
-    // Aplicar decisión del planner
-    this.applyDecision(session, lesson, decision);
+    const { advanced } = this.applyDecision(session, lesson, decision);
+    const nextTurns = await this.prepareCurrentStep(lesson, session, {
+      forcePrompt: advanced
+    });
+
     this.sessionRepo.save(session);
 
     return {
-      reply: tutor.reply,
-      stepId: step.id,
+      reply: tutorTurn.text,
+      replyRole: tutorTurn.role,
+      stepId: currentStep.id,
       isFinished: session.isFinished,
       score,
-      feedback
+      feedback,
+      nextTurns: nextTurns.length > 0 ? nextTurns : undefined,
+      currentStepIndex: session.currentStepIndex
     };
   }
 
@@ -105,17 +170,75 @@ export class ChatService {
     return this.sessionRepo.get(sessionId) || null;
   }
 
-  private getCurrentStep(lesson: Lesson, session: Session) {
+  private getCurrentStep(lesson: Lesson, session: Session): Step | undefined {
     return lesson.steps[session.currentStepIndex];
   }
 
-  private applyDecision(session: Session, lesson: Lesson, decision: any): void {
+  private stepRequiresAnswer(step?: Step): boolean {
+    if (!step) return false;
+    return step.type === 'ASK' || step.type === 'EXERCISE' || step.type === 'QUIZ';
+  }
+
+  private hasTutorTurnForStep(session: Session, stepId: string): boolean {
+    return session.history.some(turn => turn.stepId === stepId && turn.role === 'tutor');
+  }
+
+  private async prepareCurrentStep(
+    lesson: Lesson,
+    session: Session,
+    options: { forcePrompt?: boolean } = {}
+  ): Promise<Turn[]> {
+    const emitted: Turn[] = [];
+    let forcePrompt = options.forcePrompt ?? false;
+
+    while (!session.isFinished) {
+      const step = this.getCurrentStep(lesson, session);
+      if (!step) {
+        session.isFinished = true;
+        break;
+      }
+
+      const shouldSendPrompt = forcePrompt || !this.hasTutorTurnForStep(session, step.id);
+
+      if (shouldSendPrompt) {
+        const tutor = await TutorAgent.handle(lesson, session, step);
+        const tutorTurn = logTurn(session, step.id, 'tutor', tutor.reply);
+        emitted.push(tutorTurn);
+      }
+
+      if (this.stepRequiresAnswer(step)) {
+        break;
+      }
+
+      session.currentStepIndex += 1;
+
+      if (session.currentStepIndex >= lesson.steps.length) {
+        session.isFinished = true;
+        break;
+      }
+
+      forcePrompt = true;
+    }
+
+    return emitted;
+  }
+
+  private applyDecision(
+    session: Session,
+    lesson: Lesson,
+    decision: { nextIndex: number }
+  ): { advanced: boolean } {
+    const previousIndex = session.currentStepIndex;
     const { nextIndex } = decision;
-    
+
     if (nextIndex >= lesson.steps.length) {
       session.isFinished = true;
-    } else {
-      session.currentStepIndex = nextIndex;
+      return { advanced: false };
     }
+
+    const safeIndex = Math.max(0, nextIndex);
+    session.currentStepIndex = safeIndex;
+
+    return { advanced: safeIndex !== previousIndex };
   }
 }

--- a/backend/src/core/models/index.ts
+++ b/backend/src/core/models/index.ts
@@ -43,7 +43,7 @@ export interface Session {
 
 export interface Turn {
   stepId: string;
-  role: "tutor" | "student" | "verifier" | "help" | "system" | "socratic";
+  role: "tutor" | "student" | "verifier" | "help" | "system" | "socratic" | "planner";
   text: string;
   score?: number;
   findings?: string[];

--- a/backend/src/infrastructure/repositories/session.repo.ts
+++ b/backend/src/infrastructure/repositories/session.repo.ts
@@ -43,13 +43,13 @@ export class SessionRepo {
 }
 
 export function logTurn(
-  session: Session, 
-  stepId: string, 
-  role: Turn['role'], 
-  text: string, 
-  score?: number, 
+  session: Session,
+  stepId: string,
+  role: Turn['role'],
+  text: string,
+  score?: number,
   findings?: string[]
-): void {
+): Turn {
   const turn: Turn = {
     stepId,
     role,
@@ -59,4 +59,5 @@ export function logTurn(
   };
 
   session.history.push(turn);
+  return turn;
 }


### PR DESCRIPTION
## Summary
- bootstrap lessons by auto-generating tutor turns when a session is created and expose upcoming step prompts through the chat service
- enrich the multi-agent orchestration with planner, verifier, socratic, and help turns while returning role-aware replies and lesson metadata
- refresh the frontend chat to render new agent turns, track lesson progress, and react to server-provided prompts for any lesson

## Testing
- npm run build:backend

------
https://chatgpt.com/codex/tasks/task_b_68d95f5f282c832cabd3d66c061dadda